### PR TITLE
fix: Protect draw_tracked_points against out_of_range error

### DIFF
--- a/src/viewer.cc
+++ b/src/viewer.cc
@@ -343,6 +343,9 @@ unsigned int viewer::draw_tracked_points(
     std::vector<std::pair<double, unsigned int>> distance_and_keypoint_idx;
     bool keypoint_exists = false;
     for (unsigned int i = 0; i < keypoints.size(); ++i) {
+        if (i >= landmarks.size()){
+            continue;
+        }
         const auto& lm = landmarks.at(i);
         if (!lm) {
             continue;


### PR DESCRIPTION
std::vector [throws an out-of-bounds](https://cplusplus.com/reference/vector/vector/at/#:~:text=If%20this%20is%20greater%20than%2C%20or%20equal%20to%2C%20the%20vector%20size%2C%20an%20exception%20of%20type%20out_of_range%20is%20thrown.) error if .at(int i) is called with an index greater than the .size().  Add a check to continue in the case the keypoints vector is larger than the landmarks vector.