### PR TITLE
BREAKING CHANGE: Use latest stella_vslam get_keypoints_and_landmarks() function

### DIFF
--- a/src/viewer.cc
+++ b/src/viewer.cc
@@ -275,8 +275,9 @@ void viewer::run() {
         if (img.channels() == 1) {
             cvtColor(img, img, cv::COLOR_GRAY2BGR);
         }
-        auto frame_landmarks = frame_publisher_->get_landmarks();
-        auto keypoints = frame_publisher_->get_keypoints();
+        auto keypoints_and_landmarks = frame_publisher_->get_keypoints_and_landmarks();
+        auto keypoints = keypoints_and_landmarks.first;
+        auto frame_landmarks = keypoints_and_landmarks.second;
         draw_tracked_points(img, keypoints, frame_landmarks, frame_publisher_->get_mapping_is_enabled());
         texture_ = glk::create_texture(img);
 


### PR DESCRIPTION
Implements fix for #2 , waiting on Stella VSLAM's [#628](https://github.com/stella-cv/stella_vslam/pull/628) to be merged first.

I am not the most familiar with handling breaking changes, so suggestions open (e.g. 'use #ifdef' somewhere, etc.).