### PR TITLE
fix: Added C++ version requirement for optional package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,10 @@ find_package(Iridescence REQUIRED)
 
 # ----- Set build type -----
 
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_BUILD_TYPE "Release")
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release")


### PR DESCRIPTION
`std::optional` is only supported starting from C++17. Trying to install with earlier version will results in the following error.

```
error: ‘optional’ in namespace ‘std’ does not n
ame a template type                                                                                                                                           
  125 |     std::optional<Eigen::Vector3f> clicked_point3d_;
```

Solution for this is to explicitly require C++17 or above. This is consistant with the iridescence package which also requires this version https://github.com/koide3/iridescence/blob/master/CMakeLists.txt#L17